### PR TITLE
[mission001] todolist crud

### DIFF
--- a/mission001/hsna7024/.eslintrc.json
+++ b/mission001/hsna7024/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": [
+    "airbnb-base"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "linebreak-style": 0,
+    "import/extensions": 0,
+    "quotes": 0,
+    "arrow-parens": 0,
+    "object-curly-newline": 0,
+    "comma-dangle": 0
+  }
+}

--- a/mission001/hsna7024/.gitignore
+++ b/mission001/hsna7024/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/mission001/hsna7024/css/style.css
+++ b/mission001/hsna7024/css/style.css
@@ -1,0 +1,334 @@
+html,
+body {
+    margin: 0;
+    padding: 10px;
+}
+
+button {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: none;
+    font-size: 100%;
+    vertical-align: baseline;
+    font-family: inherit;
+    font-weight: inherit;
+    color: inherit;
+    -webkit-appearance: none;
+    appearance: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+    font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    line-height: 1.4em;
+    background: #f5f5f5;
+    color: #4d4d4d;
+    min-width: 230px;
+    max-width: 550px;
+    margin: 0 auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 300;
+}
+
+:focus {
+    outline: 0;
+}
+
+.hidden {
+    display: none;
+}
+
+.todoapp {
+    background: #fff;
+    margin: 130px 0 40px 0;
+    position: relative;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2),
+    0 25px 50px 0 rgba(0, 0, 0, 0.1);
+}
+
+.todoapp input::-webkit-input-placeholder {
+    font-style: italic;
+    font-weight: 300;
+    color: #e6e6e6;
+}
+
+.todoapp h1 {
+    position: absolute;
+    top: -125px;
+    width: 100%;
+    font-size: 60px;
+    text-align: center;
+    color: dimgray;
+    font-weight: 100;
+    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+}
+
+.new-todo,
+.edit {
+    position: relative;
+    margin: 0;
+    width: 100%;
+    font-size: 24px;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: 1.4em;
+    border: 0;
+    color: inherit;
+    padding: 6px;
+    box-shadow: inset 0 -1px 5px 0 rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+.new-todo {
+    padding: 16px 16px 16px 60px;
+    border: none;
+    background: rgba(0, 0, 0, 0.003);
+    box-shadow: inset 0 -2px 1px rgba(0,0,0,0.03);
+}
+
+.main {
+    position: relative;
+    z-index: 2;
+    border-top: 1px solid #e6e6e6;
+}
+
+.toggle-all {
+    width: 1px;
+    height: 1px;
+    border: none;
+    opacity: 0;
+    position: absolute;
+    right: 100%;
+    bottom: 100%;
+}
+
+.toggle-all + label {
+    width: 60px;
+    height: 34px;
+    font-size: 0;
+    position: absolute;
+    top: -52px;
+    left: -13px;
+    -webkit-transform: rotate(90deg);
+    transform: rotate(90deg);
+}
+
+.toggle-all + label:before {
+    content: '❯';
+    font-size: 22px;
+    color: #e6e6e6;
+    padding: 10px 27px 10px 27px;
+}
+
+.toggle-all:checked + label:before {
+    color: #737373;
+}
+
+.todo-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.todo-list li {
+    position: relative;
+    font-size: 24px;
+    border-bottom: 1px solid #ededed;
+}
+
+.todo-list li:last-child {
+    border-bottom: none;
+}
+
+.todo-list li.editing {
+    border-bottom: none;
+    padding: 0;
+}
+
+.todo-list li.editing .edit {
+    display: block;
+    width: calc(100% - 43px);
+    padding: 12px 16px;
+    margin: 0 0 0 43px;
+}
+
+.todo-list li.editing .view {
+    display: none;
+}
+
+.todo-list li .toggle {
+    text-align: center;
+    width: 40px;
+    height: auto;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    margin: auto 0;
+    border: none;
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+.todo-list li .toggle {
+    opacity: 0;
+}
+
+.todo-list li .toggle + label {
+    background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22none%22%20stroke%3D%22%23ededed%22%20stroke-width%3D%223%22/%3E%3C/svg%3E');
+    background-repeat: no-repeat;
+    background-position: center left;
+}
+
+.todo-list li .toggle:checked + label {
+    background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22none%22%20stroke%3D%22%23bddad5%22%20stroke-width%3D%223%22/%3E%3Cpath%20fill%3D%22%235dc2af%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22/%3E%3C/svg%3E');
+}
+
+.todo-list li label {
+    word-break: break-all;
+    padding: 15px 15px 15px 60px;
+    display: block;
+    line-height: 1.2;
+    transition: color 0.4s;
+}
+
+.todo-list li.completed label {
+    color: #d9d9d9;
+    text-decoration: line-through;
+}
+
+.todo-list li .destroy {
+    display: none;
+    position: absolute;
+    top: 0;
+    right: 10px;
+    bottom: 0;
+    width: 40px;
+    height: 40px;
+    margin: auto 0;
+    font-size: 30px;
+    color: #cc9a9a;
+    margin-bottom: 11px;
+    transition: color 0.2s ease-out;
+    cursor: pointer;
+}
+
+.todo-list li .destroy:hover {
+    color: #af5b5e;
+}
+
+.todo-list li .destroy:after {
+    content: '×';
+}
+
+.todo-list li:hover .destroy {
+    display: block;
+}
+
+.todo-list li .edit {
+    display: none;
+}
+
+.todo-list li.editing:last-child {
+    margin-bottom: -1px;
+}
+
+.count-container {
+    color: #777;
+    padding: 10px 15px;
+    height: 20px;
+    text-align: center;
+    border-top: 1px solid #e6e6e6;
+}
+
+.count-container:before {
+    content: '';
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 50px;
+    overflow: hidden;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2),
+    0 8px 0 -3px #f6f6f6,
+    0 9px 1px -3px rgba(0, 0, 0, 0.2),
+    0 16px 0 -6px #f6f6f6,
+    0 17px 2px -6px rgba(0, 0, 0, 0.2);
+}
+
+.todo-count {
+    float: left;
+    text-align: left;
+}
+
+.todo-count strong {
+    font-weight: 300;
+}
+
+.filters {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    position: absolute;
+    right: 0;
+    left: 0;
+}
+
+.filters li {
+    display: inline;
+}
+
+.filters li a {
+    color: inherit;
+    margin: 3px;
+    padding: 3px 7px;
+    text-decoration: none;
+    border: 1px solid transparent;
+    border-radius: 3px;
+}
+
+.filters li a:hover {
+    border-color: rgba(175, 47, 47, 0.1);
+}
+
+.filters li a.selected {
+    border-color: rgba(175, 47, 47, 0.2);
+}
+
+.clear-completed, html .clear-completed:active {
+    float: right;
+    position: relative;
+    line-height: 20px;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.clear-completed:hover {
+    text-decoration: underline;
+}
+
+.info {
+    margin: 65px auto 0;
+    color: #bfbfbf;
+    font-size: 10px;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+    text-align: center;
+}
+
+.info p {
+    line-height: 1;
+}
+
+.info a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 400;
+}
+
+.info a:hover {
+    text-decoration: underline;
+}

--- a/mission001/hsna7024/index.html
+++ b/mission001/hsna7024/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>이벤트 - TODOS</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<section class="todoapp">
+  <div>
+    <h1>TODOS</h1>
+    <input id="new-todo-title" class="new-todo" placeholder="할일을 추가해주세요" autofocus>
+  </div>
+  <div class="main">
+    <input class="toggle-all" type="checkbox">
+    <ul id="todo-list" class="todo-list">
+      <li>
+        <div class="view">
+          <input class="toggle" type="checkbox">
+          <label class="label">새로운 타이틀</label>
+          <button class="destroy"></button>
+        </div>
+        <input class="edit" value="새로운 타이틀">
+      </li>
+      <li class="editing">
+        <div class="view">
+          <input class="toggle" type="checkbox">
+          <label class="label">완료된 타이틀</label>
+          <button class="destroy"></button>
+        </div>
+        <input class="edit" value="완료된 타이틀">
+      </li>
+      <li class="completed">
+        <div class="view">
+          <input class="toggle" type="checkbox">
+          <label class="label">완료된 타이틀</label>
+          <button class="destroy"></button>
+        </div>
+        <input class="edit" value="완료된 타이틀">
+      </li>
+    </ul>
+  </div>
+  <div class="count-container">
+    <span class="todo-count">총 <strong>0</strong> 개</span>
+    <ul class="filters">
+      <li>
+        <a class="all selected" href="#/">전체보기</a>
+      </li>
+      <li>
+        <a class="active" href="#/active">해야할 일</a>
+      </li>
+      <li>
+        <a class="completed" href="#/completed">완료한 일</a>
+      </li>
+    </ul>
+  </div>
+</section>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/mission001/hsna7024/index.html
+++ b/mission001/hsna7024/index.html
@@ -56,6 +56,6 @@
     </ul>
   </div>
 </section>
-<script src="js/app.js"></script>
+<script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -2,7 +2,7 @@ import TodoList from "./TodoList.js";
 import TodoInput from "./TodoInput.js";
 import TodoCount from "./TodoCount.js";
 import TodoFilter from "./TodoFilter.js";
-import { filters } from "./utils/constants.js";
+import { filterMap } from "./utils/constants.js";
 
 export default function App(params) {
   const {
@@ -12,13 +12,13 @@ export default function App(params) {
     $targetTodoFilter
   } = params;
   let data = params.data || [];
-  let filter = params.filter || filters.ALL;
+  let filter = params.filter || filterMap.ALL;
 
   const filterTodos = (todos, filter) => {
     switch (filter) {
-      case filters.ACTIVE:
+      case filterMap.ACTIVE:
         return todos.filter(todo => !todo.isCompleted);
-      case filters.COMPLETED:
+      case filterMap.COMPLETED:
         return todos.filter(todo => todo.isCompleted);
       default:
         return todos;

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -52,7 +52,7 @@ export default function App(params) {
 
   const todoCount = new TodoCount({
     $target: $targetTodoCount,
-    count : data.length
+    count: data.length
   });
 
   const todoFilter = new TodoFilter({

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -8,7 +8,11 @@ export default function App(params) {
 
   const todoList = new TodoList({
     $target: $targetTodoList,
-    data
+    data,
+    toggleTodo: id => {
+      data[id].isCompleted = !data[id].isCompleted;
+      this.render();
+    }
   });
 
   const todoInput = new TodoInput({
@@ -24,7 +28,7 @@ export default function App(params) {
   const todoCount = new TodoCount({
     $target: $targetTodoCount,
     data
-  })
+  });
 
   this.setState = nextData => {
     data = nextData;

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -1,0 +1,23 @@
+import TodoList from "./TodoList.js";
+
+export default function App(params) {
+  const $targetTodoList = params.$targetTodoList;
+  let data = params.data || [];
+
+  const todoList = new TodoList({
+    $target: $targetTodoList,
+    data
+  });
+
+  this.setState = nextData => {
+    data = nextData;
+    todoList.setState(data);
+    this.render();
+  };
+
+  this.render = () => {
+    todoList.render();
+  };
+
+  this.render();
+}

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -12,6 +12,10 @@ export default function App(params) {
     toggleTodo: id => {
       data[id].isCompleted = !data[id].isCompleted;
       this.render();
+    },
+    removeTodo: id => {
+      data.splice(id, 1);
+      this.render();
     }
   });
 

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -1,12 +1,23 @@
 import TodoList from "./TodoList.js";
+import TodoInput from "./TodoInput.js";
 
 export default function App(params) {
-  const $targetTodoList = params.$targetTodoList;
+  const { $targetTodoList, $targetTodoInput } = params;
   let data = params.data || [];
 
   const todoList = new TodoList({
     $target: $targetTodoList,
     data
+  });
+
+  const todoInput = new TodoInput({
+    $target: $targetTodoInput,
+    onKeyEnter: content => {
+      data.push({
+        content
+      });
+      this.render();
+    }
   });
 
   this.setState = nextData => {

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -52,7 +52,7 @@ export default function App(params) {
 
   const todoCount = new TodoCount({
     $target: $targetTodoCount,
-    data
+    count : data.length
   });
 
   const todoFilter = new TodoFilter({
@@ -67,7 +67,7 @@ export default function App(params) {
     data = nextData;
     filter = nextFilter;
     todoList.setState(data, filter);
-    todoCount.setState(filterTodos(data, filter));
+    todoCount.setState(filterTodos(data, filter).length);
     todoFilter.setState(filter);
     this.render();
   };

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -1,8 +1,9 @@
 import TodoList from "./TodoList.js";
 import TodoInput from "./TodoInput.js";
+import TodoCount from "./TodoCount.js";
 
 export default function App(params) {
-  const { $targetTodoList, $targetTodoInput } = params;
+  const { $targetTodoList, $targetTodoInput, $targetTodoCount } = params;
   let data = params.data || [];
 
   const todoList = new TodoList({
@@ -20,14 +21,21 @@ export default function App(params) {
     }
   });
 
+  const todoCount = new TodoCount({
+    $target: $targetTodoCount,
+    data
+  })
+
   this.setState = nextData => {
     data = nextData;
     todoList.setState(data);
+    todoCount.setState(data);
     this.render();
   };
 
   this.render = () => {
     todoList.render();
+    todoCount.render();
   };
 
   this.render();

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -9,18 +9,21 @@ export default function App(params) {
     $targetTodoList,
     $targetTodoInput,
     $targetTodoCount,
-    $targetTodoFilter,
+    $targetTodoFilter
   } = params;
   let data = params.data || [];
-  let filter = params.data || filters.ALL;
+  let filter = params.filter || filters.ALL;
 
   const filterTodos = (todos, filter) => {
-    switch(filter){
-      case filters.ACTIVE: return todos.filter(todo => !todo.isCompleted);
-      case filters.COMPLETED: return todos.filter(todo => todo.isCompleted);
-      default : return todos;
+    switch (filter) {
+      case filters.ACTIVE:
+        return todos.filter(todo => !todo.isCompleted);
+      case filters.COMPLETED:
+        return todos.filter(todo => todo.isCompleted);
+      default:
+        return todos;
     }
-  }
+  };
 
   const todoList = new TodoList({
     $target: $targetTodoList,
@@ -56,20 +59,23 @@ export default function App(params) {
     $target: $targetTodoFilter,
     changeFilter: nextFilter => {
       this.setState(data, nextFilter);
-    }
+    },
+    filter
   });
 
   this.setState = (nextData, nextFilter) => {
     data = nextData;
-    filter = nextFilter
+    filter = nextFilter;
     todoList.setState(data, filter);
     todoCount.setState(filterTodos(data, filter));
+    todoFilter.setState(filter);
     this.render();
   };
 
   this.render = () => {
     todoList.render();
     todoCount.render();
+    todoFilter.render();
   };
 
   this.render();

--- a/mission001/hsna7024/js/App.js
+++ b/mission001/hsna7024/js/App.js
@@ -1,10 +1,26 @@
 import TodoList from "./TodoList.js";
 import TodoInput from "./TodoInput.js";
 import TodoCount from "./TodoCount.js";
+import TodoFilter from "./TodoFilter.js";
+import { filters } from "./utils/constants.js";
 
 export default function App(params) {
-  const { $targetTodoList, $targetTodoInput, $targetTodoCount } = params;
+  const {
+    $targetTodoList,
+    $targetTodoInput,
+    $targetTodoCount,
+    $targetTodoFilter,
+  } = params;
   let data = params.data || [];
+  let filter = params.data || filters.ALL;
+
+  const filterTodos = (todos, filter) => {
+    switch(filter){
+      case filters.ACTIVE: return todos.filter(todo => !todo.isCompleted);
+      case filters.COMPLETED: return todos.filter(todo => todo.isCompleted);
+      default : return todos;
+    }
+  }
 
   const todoList = new TodoList({
     $target: $targetTodoList,
@@ -16,7 +32,9 @@ export default function App(params) {
     removeTodo: id => {
       data.splice(id, 1);
       this.render();
-    }
+    },
+    filter,
+    filterTodos
   });
 
   const todoInput = new TodoInput({
@@ -34,10 +52,18 @@ export default function App(params) {
     data
   });
 
-  this.setState = nextData => {
+  const todoFilter = new TodoFilter({
+    $target: $targetTodoFilter,
+    changeFilter: nextFilter => {
+      this.setState(data, nextFilter);
+    }
+  });
+
+  this.setState = (nextData, nextFilter) => {
     data = nextData;
-    todoList.setState(data);
-    todoCount.setState(data);
+    filter = nextFilter
+    todoList.setState(data, filter);
+    todoCount.setState(filterTodos(data, filter));
     this.render();
   };
 

--- a/mission001/hsna7024/js/TodoCount.js
+++ b/mission001/hsna7024/js/TodoCount.js
@@ -1,0 +1,13 @@
+export default function TodoCount(params) {
+  const { $target } = params;
+  const data = params.data || [];
+
+  this.setState = nextData => {
+    data = nextData;
+    this.render();
+  };
+
+  this.render = () => {
+    $target.innerHTML = `총 <strong>${data.length}</strong> 개`;
+  };
+}

--- a/mission001/hsna7024/js/TodoCount.js
+++ b/mission001/hsna7024/js/TodoCount.js
@@ -1,6 +1,6 @@
 export default function TodoCount(params) {
   const { $target } = params;
-  const data = params.data || [];
+  let data = params.data || [];
 
   this.setState = nextData => {
     data = nextData;

--- a/mission001/hsna7024/js/TodoCount.js
+++ b/mission001/hsna7024/js/TodoCount.js
@@ -1,10 +1,11 @@
 import { todoCountTemplate } from "./utils/templates.js";
+import { errorMessageMap } from "./utils/constants.js";
 
 export default function TodoCount(params) {
   const { $target } = params;
   let count = params.count || 0;
 
-  if($target === null) {
+  if ($target === null) {
     throw new Error(errorMessageMap.IS_NO_TARGET);
   }
 

--- a/mission001/hsna7024/js/TodoCount.js
+++ b/mission001/hsna7024/js/TodoCount.js
@@ -4,6 +4,10 @@ export default function TodoCount(params) {
   const { $target } = params;
   let data = params.data || [];
 
+  if($target === null) {
+    throw new Error(errorMessageMap.IS_NO_TARGET);
+  }
+
   this.setState = nextData => {
     data = nextData;
     this.render();

--- a/mission001/hsna7024/js/TodoCount.js
+++ b/mission001/hsna7024/js/TodoCount.js
@@ -2,18 +2,18 @@ import { todoCountTemplate } from "./utils/templates.js";
 
 export default function TodoCount(params) {
   const { $target } = params;
-  let data = params.data || [];
+  let count = params.count || 0;
 
   if($target === null) {
     throw new Error(errorMessageMap.IS_NO_TARGET);
   }
 
-  this.setState = nextData => {
-    data = nextData;
+  this.setState = nextCount => {
+    count = nextCount;
     this.render();
   };
 
   this.render = () => {
-    $target.innerHTML = todoCountTemplate(data.length);
+    $target.innerHTML = todoCountTemplate(count);
   };
 }

--- a/mission001/hsna7024/js/TodoCount.js
+++ b/mission001/hsna7024/js/TodoCount.js
@@ -1,3 +1,5 @@
+import { todoCountTemplate } from "./utils/templates.js";
+
 export default function TodoCount(params) {
   const { $target } = params;
   let data = params.data || [];
@@ -8,6 +10,6 @@ export default function TodoCount(params) {
   };
 
   this.render = () => {
-    $target.innerHTML = `총 <strong>${data.length}</strong> 개`;
+    $target.innerHTML = todoCountTemplate(data.length);
   };
 }

--- a/mission001/hsna7024/js/TodoFilter.js
+++ b/mission001/hsna7024/js/TodoFilter.js
@@ -1,10 +1,11 @@
 import { todoFilterTemplate } from "./utils/templates.js";
+import { errorMessageMap } from "./utils/constants.js";
 
 export default function TodoFilter(params) {
   const { $target, changeFilter } = params;
   let filter = params.filter || "";
 
-  if($target === null) {
+  if ($target === null) {
     throw new Error(errorMessageMap.IS_NO_TARGET);
   }
 

--- a/mission001/hsna7024/js/TodoFilter.js
+++ b/mission001/hsna7024/js/TodoFilter.js
@@ -8,6 +8,8 @@ export default function TodoFilter(params) {
   });
 
   this.render = () => {
-    $target.innerHTML = todoFilterTemplate;
+    $target.innerHTML = todoFilterTemplate();
   };
+
+  this.render();
 }

--- a/mission001/hsna7024/js/TodoFilter.js
+++ b/mission001/hsna7024/js/TodoFilter.js
@@ -1,0 +1,20 @@
+export default function TodoFilter(params) {
+  const { $target, changeFilter } = params;
+
+  $target.addEventListener("click", e => {
+    changeFilter(e.target.className);
+  });
+
+  this.render = () => {
+    $target.innerHTML = `
+    <li>
+      <a class="all selected" href="#/">전체보기</a>
+    </li>
+    <li>
+      <a class="active" href="#/active">해야할 일</a>
+    </li>
+    <li>
+      <a class="completed" href="#/completed">완료한 일</a>
+    </li>`;
+  };
+}

--- a/mission001/hsna7024/js/TodoFilter.js
+++ b/mission001/hsna7024/js/TodoFilter.js
@@ -4,6 +4,10 @@ export default function TodoFilter(params) {
   const { $target, changeFilter } = params;
   let filter = params.filter || "";
 
+  if($target === null) {
+    throw new Error(errorMessageMap.IS_NO_TARGET);
+  }
+
   $target.addEventListener("click", e => {
     changeFilter(e.target.className);
   });

--- a/mission001/hsna7024/js/TodoFilter.js
+++ b/mission001/hsna7024/js/TodoFilter.js
@@ -2,13 +2,19 @@ import { todoFilterTemplate } from "./utils/templates.js";
 
 export default function TodoFilter(params) {
   const { $target, changeFilter } = params;
+  let filter = params.filter || "";
 
   $target.addEventListener("click", e => {
     changeFilter(e.target.className);
   });
 
+  this.setState = nextFilter => {
+    filter = nextFilter;
+    this.render();
+  };
+
   this.render = () => {
-    $target.innerHTML = todoFilterTemplate();
+    $target.innerHTML = todoFilterTemplate(filter);
   };
 
   this.render();

--- a/mission001/hsna7024/js/TodoFilter.js
+++ b/mission001/hsna7024/js/TodoFilter.js
@@ -1,3 +1,5 @@
+import { todoFilterTemplate } from "./utils/templates.js";
+
 export default function TodoFilter(params) {
   const { $target, changeFilter } = params;
 
@@ -6,15 +8,6 @@ export default function TodoFilter(params) {
   });
 
   this.render = () => {
-    $target.innerHTML = `
-    <li>
-      <a class="all selected" href="#/">전체보기</a>
-    </li>
-    <li>
-      <a class="active" href="#/active">해야할 일</a>
-    </li>
-    <li>
-      <a class="completed" href="#/completed">완료한 일</a>
-    </li>`;
+    $target.innerHTML = todoFilterTemplate;
   };
 }

--- a/mission001/hsna7024/js/TodoInput.js
+++ b/mission001/hsna7024/js/TodoInput.js
@@ -1,10 +1,10 @@
+import { keyCodes } from "./utils/constants.js";
+
 export default function TodoInput(params) {
   const { $target, onKeyEnter } = params;
 
   $target.addEventListener("keydown", e => {
-    const ENTER_KEY_CODE = 13;
-
-    if (e.keyCode === ENTER_KEY_CODE) {
+    if (e.keyCode === keyCodes.ENTER) {
       onKeyEnter($target.value);
       $target.value = "";
     }

--- a/mission001/hsna7024/js/TodoInput.js
+++ b/mission001/hsna7024/js/TodoInput.js
@@ -1,14 +1,14 @@
-import { keyMap } from "./utils/constants.js";
+import { keyMap, errorMessageMap } from "./utils/constants.js";
 
 export default function TodoInput(params) {
   const { $target, onKeyEnter } = params;
 
-  if($target === null) {
+  if ($target === null) {
     throw new Error(errorMessageMap.IS_NO_TARGET);
   }
 
   $target.addEventListener("keydown", e => {
-    if (e.key === keyMap.ENTER  && $target.value) {
+    if (e.key === keyMap.ENTER && $target.value) {
       onKeyEnter($target.value);
       $target.value = "";
     }

--- a/mission001/hsna7024/js/TodoInput.js
+++ b/mission001/hsna7024/js/TodoInput.js
@@ -8,7 +8,7 @@ export default function TodoInput(params) {
   }
 
   $target.addEventListener("keydown", e => {
-    if (e.keyCode === keyCodeMap.ENTER) {
+    if (e.keyCode === keyCodeMap.ENTER && $target.value) {
       onKeyEnter($target.value);
       $target.value = "";
     }

--- a/mission001/hsna7024/js/TodoInput.js
+++ b/mission001/hsna7024/js/TodoInput.js
@@ -3,6 +3,10 @@ import { keyCodeMap } from "./utils/constants.js";
 export default function TodoInput(params) {
   const { $target, onKeyEnter } = params;
 
+  if($target === null) {
+    throw new Error(errorMessageMap.IS_NO_TARGET);
+  }
+
   $target.addEventListener("keydown", e => {
     if (e.keyCode === keyCodeMap.ENTER) {
       onKeyEnter($target.value);

--- a/mission001/hsna7024/js/TodoInput.js
+++ b/mission001/hsna7024/js/TodoInput.js
@@ -1,10 +1,10 @@
-import { keyCodes } from "./utils/constants.js";
+import { keyCodeMap } from "./utils/constants.js";
 
 export default function TodoInput(params) {
   const { $target, onKeyEnter } = params;
 
   $target.addEventListener("keydown", e => {
-    if (e.keyCode === keyCodes.ENTER) {
+    if (e.keyCode === keyCodeMap.ENTER) {
       onKeyEnter($target.value);
       $target.value = "";
     }

--- a/mission001/hsna7024/js/TodoInput.js
+++ b/mission001/hsna7024/js/TodoInput.js
@@ -1,4 +1,4 @@
-import { keyCodeMap } from "./utils/constants.js";
+import { keyMap } from "./utils/constants.js";
 
 export default function TodoInput(params) {
   const { $target, onKeyEnter } = params;
@@ -8,7 +8,7 @@ export default function TodoInput(params) {
   }
 
   $target.addEventListener("keydown", e => {
-    if (e.keyCode === keyCodeMap.ENTER && $target.value) {
+    if (e.key === keyMap.ENTER  && $target.value) {
       onKeyEnter($target.value);
       $target.value = "";
     }

--- a/mission001/hsna7024/js/TodoInput.js
+++ b/mission001/hsna7024/js/TodoInput.js
@@ -1,0 +1,12 @@
+export default function TodoInput(params) {
+  const { $target, onKeyEnter } = params;
+
+  $target.addEventListener("keydown", e => {
+    const ENTER_KEY_CODE = 13;
+
+    if (e.keyCode === ENTER_KEY_CODE) {
+      onKeyEnter($target.value);
+      $target.value = "";
+    }
+  });
+}

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -2,12 +2,13 @@ import { classNameMap, keyMap, errorMessageMap } from "./utils/constants.js";
 import { todoListTemplate } from "./utils/templates.js";
 
 export default function TodoList(params) {
-  const { $target, toggleTodo, removeTodo, filterTodos } = params;
+  const { $target, toggleTodo, removeTodo, filterTodos 
+} = params;
   let data = params.data || [];
   let filter = params.filter || "";
   let filteredData = [];
 
-  if($target === null) {
+  if ($target === null) {
     throw new Error(errorMessageMap.IS_NO_TARGET);
   }
 
@@ -15,8 +16,7 @@ export default function TodoList(params) {
     const { id } = e.target.closest("li").dataset;
     if (e.target.classList.contains(classNameMap.TOGGLE)) {
       toggleTodo(id);
-    }
-    else if (e.target.classList.contains(classNameMap.REMOVE)) {
+    } else if (e.target.classList.contains(classNameMap.REMOVE)) {
       removeTodo(id);
     }
   });
@@ -36,8 +36,7 @@ export default function TodoList(params) {
         data[id].content = e.target.value;
         data[id].onEdit = false;
         this.render();
-      }
-      else if (e.key === keyMap.ESC) {
+      } else if (e.key === keyMap.ESC) {
         data[id].onEdit = false;
         this.render();
       }

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -12,7 +12,7 @@ export default function TodoList(params) {
   }
 
   $target.addEventListener("click", e => {
-    const { id } = e.toElement.parentElement.parentElement.dataset;
+    const { id } = e.target.closest("li").dataset;
     if (e.target.className === classNameMap.TOGGLE) {
       toggleTodo(id);
     }
@@ -23,7 +23,7 @@ export default function TodoList(params) {
 
   $target.addEventListener("dblclick", e => {
     if (e.target.className === classNameMap.LABEL) {
-      const { id } = e.toElement.parentElement.parentElement.dataset;
+      const { id } = e.target.closest("li").dataset;
       data[id].onEdit = true;
       this.render();
     }
@@ -31,7 +31,7 @@ export default function TodoList(params) {
 
   $target.addEventListener("keydown", e => {
     if (e.target.className === classNameMap.EDIT) {
-      const { id } = e.target.parentElement.dataset;
+      const { id } = e.target.closest("li").dataset;
       if (e.key === keyMap.ENTER && e.target.value) {
         data[id].content = e.target.value;
         data[id].onEdit = false;

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,0 +1,24 @@
+export default function TodoList(params) {
+  const $target = params.$target;
+  let data = params.data || [];
+
+  this.setState = nextData => {
+    data = nextData;
+    this.render();
+  };
+
+  this.render = () => {
+    $target.innerHTML = data
+      .map((todo, index) => {
+        return `<li data-id="${index}">
+        <div class="view">
+         <input class="toggle" type="checkbox">
+         <label class="label">${todo.content}</label>
+         <button class="destroy"></button>
+       </div></li>`;
+      })
+      .join("");
+  };
+
+  this.render();
+}

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,4 +1,4 @@
-import { classNameMap, keyCodeMap, errorMessageMap } from "./utils/constants.js";
+import { classNameMap, keyMap, errorMessageMap } from "./utils/constants.js";
 import { todoListTemplate } from "./utils/templates.js";
 
 export default function TodoList(params) {
@@ -32,12 +32,12 @@ export default function TodoList(params) {
   $target.addEventListener("keydown", e => {
     if (e.target.className === classNameMap.EDIT) {
       const { id } = e.target.parentElement.dataset;
-      if (e.keyCode === keyCodeMap.ENTER && e.target.value) {
+      if (e.key === keyMap.ENTER && e.target.value) {
         data[id].content = e.target.value;
         data[id].onEdit = false;
         this.render();
       }
-      if (e.keyCode === keyCodeMap.ESC) {
+      if (e.key === keyMap.ESC) {
         data[id].onEdit = false;
         this.render();
       }

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,4 +1,4 @@
-import { classNames, keyCodes } from "./utils/constants.js";
+import { classNameMap, keyCodeMap } from "./utils/constants.js";
 import { todoListTemplate } from "./utils/templates.js";
 
 export default function TodoList(params) {
@@ -9,16 +9,16 @@ export default function TodoList(params) {
 
   $target.addEventListener("click", e => {
     const { id } = e.toElement.parentElement.parentElement.dataset;
-    if (e.target.className === classNames.TOGGLE) {
+    if (e.target.className === classNameMap.TOGGLE) {
       toggleTodo(id);
     }
-    if (e.target.className === classNames.REMOVE) {
+    if (e.target.className === classNameMap.REMOVE) {
       removeTodo(id);
     }
   });
 
   $target.addEventListener("dblclick", e => {
-    if (e.target.className === classNames.LABEL) {
+    if (e.target.className === classNameMap.LABEL) {
       const { id } = e.toElement.parentElement.parentElement.dataset;
       data[id].onEdit = true;
       this.render();
@@ -26,14 +26,14 @@ export default function TodoList(params) {
   });
 
   $target.addEventListener("keydown", e => {
-    if (e.target.className === classNames.EDIT) {
-      if (e.keyCode === keyCodes.ENTER) {
+    if (e.target.className === classNameMap.EDIT) {
+      if (e.keyCode === keyCodeMap.ENTER) {
         const { id } = e.target.parentElement.dataset;
         data[id].content = e.target.value;
         data[id].onEdit = false;
         this.render();
       }
-      if (e.keyCode === keyCodes.ESC) {
+      if (e.keyCode === keyCodeMap.ESC) {
         const { id } = e.target.parentElement.dataset;
         data[id].onEdit = false;
         this.render();

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,6 +1,8 @@
 export default function TodoList(params) {
-  const { $target, toggleTodo, removeTodo } = params;
+  const { $target, toggleTodo, removeTodo, filterTodos } = params;
   let data = params.data || [];
+  let filter = params.filter || "";
+  let filteredData = [];
 
   $target.addEventListener("click", e => {
     const { id } = e.toElement.parentElement.parentElement.dataset;
@@ -38,15 +40,20 @@ export default function TodoList(params) {
     }
   });
 
-  this.setState = nextData => {
-    data = nextData;
+  filteredData = filterTodos(data, filter)
+
+  this.setState = (nextData, nextFilter) => {
+    data = nextData || data;
+    filter = nextFilter || filter;
+    console.log(filter)
+    filteredData = filterTodos(data, filter)
     this.render();
   };
 
   this.render = () => {
-    $target.innerHTML = data
+    $target.innerHTML = filteredData
       .map((todo, index) => {
-        const contentHtmlString = `<div class="view">
+        const contentHtmlString = `<div class="view"> 
         <input class="toggle" type="checkbox" ${
           todo.isCompleted ? "checked" : ""
         }>

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -22,7 +22,7 @@ export default function TodoList(params) {
   });
 
   $target.addEventListener("dblclick", e => {
-    if (e.target.className === classNameMap.LABEL) {
+    if (e.target.classList.contains(classNameMap.LABEL)) {
       const { id } = e.target.closest("li").dataset;
       data[id].onEdit = true;
       this.render();
@@ -30,7 +30,7 @@ export default function TodoList(params) {
   });
 
   $target.addEventListener("keydown", e => {
-    if (e.target.className === classNameMap.EDIT) {
+    if (e.target.classList.contains(classNameMap.EDIT)) {
       const { id } = e.target.closest("li").dataset;
       if (e.key === keyMap.ENTER && e.target.value) {
         data[id].content = e.target.value;

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,4 +1,4 @@
-import { classNameMap, keyCodeMap } from "./utils/constants.js";
+import { classNameMap, keyCodeMap, errorMessageMap } from "./utils/constants.js";
 import { todoListTemplate } from "./utils/templates.js";
 
 export default function TodoList(params) {
@@ -6,6 +6,10 @@ export default function TodoList(params) {
   let data = params.data || [];
   let filter = params.filter || "";
   let filteredData = [];
+
+  if($target === null) {
+    throw new Error(errorMessageMap.IS_NO_TARGET);
+  }
 
   $target.addEventListener("click", e => {
     const { id } = e.toElement.parentElement.parentElement.dataset;

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -27,14 +27,13 @@ export default function TodoList(params) {
 
   $target.addEventListener("keydown", e => {
     if (e.target.className === classNameMap.EDIT) {
+      const { id } = e.target.parentElement.dataset;
       if (e.keyCode === keyCodeMap.ENTER) {
-        const { id } = e.target.parentElement.dataset;
         data[id].content = e.target.value;
         data[id].onEdit = false;
         this.render();
       }
       if (e.keyCode === keyCodeMap.ESC) {
-        const { id } = e.target.parentElement.dataset;
         data[id].onEdit = false;
         this.render();
       }

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -2,6 +2,14 @@ export default function TodoList(params) {
   const { $target } = params;
   let data = params.data || [];
 
+  $target.addEventListener("click", e => {
+    if (e.target.className === "toggle") {
+      const { id } = e.toElement.parentElement.parentElement.dataset
+      data[id].isCompleted = e.toElement.checked
+      this.render();
+    }
+  });
+
   this.setState = nextData => {
     data = nextData;
     this.render();
@@ -10,7 +18,15 @@ export default function TodoList(params) {
   this.render = () => {
     $target.innerHTML = data
       .map((todo, index) => {
-        return `<li data-id="${index}">
+        return todo.isCompleted
+        ? `<li class="completed" data-id="${index}">
+        <div class="view">
+         <input class="toggle" type="checkbox" checked="true">
+         <label class="label">${todo.content}</label>
+         <button class="destroy"></button>
+       </div></li>`
+        :
+        `<li data-id="${index}">
         <div class="view">
          <input class="toggle" type="checkbox">
          <label class="label">${todo.content}</label>

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -5,6 +5,7 @@ export default function TodoList(params) {
   $target.addEventListener("click", e => {
     if (e.target.className === "toggle") {
       const { id } = e.toElement.parentElement.parentElement.dataset;
+      console.log(e.toElement.checked);
       data[id].isCompleted = e.toElement.checked;
       this.render();
     }
@@ -16,6 +17,32 @@ export default function TodoList(params) {
     }
   });
 
+  $target.addEventListener("dblclick", e => {
+    if (e.target.className === "label") {
+      const { id } = e.toElement.parentElement.parentElement.dataset;
+      data[id].onEdit = true;
+      this.render();
+    }
+  });
+
+  $target.addEventListener("keydown", e => {
+    if (e.target.className === "edit") {
+      const ENTER_KEY_CODE = 13;
+      const ESC_KEY_CODE = 27;
+      if (e.keyCode === ENTER_KEY_CODE) {
+        const { id } = e.target.parentElement.dataset;
+        data[id].content = e.target.value;
+        data[id].onEdit = false;
+        this.render();
+      }
+      if (e.keyCode === ESC_KEY_CODE) {
+        const { id } = e.target.parentElement.dataset;
+        data[id].onEdit = false;
+        this.render();
+      }
+    }
+  });
+
   this.setState = nextData => {
     data = nextData;
     this.render();
@@ -24,19 +51,19 @@ export default function TodoList(params) {
   this.render = () => {
     $target.innerHTML = data
       .map((todo, index) => {
-        return todo.isCompleted
-          ? `<li class="completed" data-id="${index}">
-        <div class="view">
-         <input class="toggle" type="checkbox" checked="true">
-         <label class="label">${todo.content}</label>
-         <button class="destroy"></button>
-       </div></li>`
-          : `<li data-id="${index}">
-        <div class="view">
-         <input class="toggle" type="checkbox">
-         <label class="label">${todo.content}</label>
-         <button class="destroy"></button>
-       </div></li>`;
+        const contentHtmlString = `<div class="view">
+        <input class="toggle" type="checkbox" ${
+          todo.isCompleted ? "checked" : ""
+        }>
+        <label class="label">${todo.content}</label>
+        <button class="destroy"></button></div>
+        <input class="edit" value="${todo.content}">`;
+        const completedClassName = todo.isCompleted
+          ? `class = "completed"`
+          : "";
+        const editingClassName = todo.onEdit ? `class = "editing"` : "";
+
+        return `<li ${completedClassName} ${editingClassName} data-id="${index}">${contentHtmlString}</li>`;
       })
       .join("");
   };

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -16,7 +16,7 @@ export default function TodoList(params) {
     if (e.target.className === classNameMap.TOGGLE) {
       toggleTodo(id);
     }
-    if (e.target.className === classNameMap.REMOVE) {
+    else if (e.target.className === classNameMap.REMOVE) {
       removeTodo(id);
     }
   });
@@ -37,7 +37,7 @@ export default function TodoList(params) {
         data[id].onEdit = false;
         this.render();
       }
-      if (e.key === keyMap.ESC) {
+      else if (e.key === keyMap.ESC) {
         data[id].onEdit = false;
         this.render();
       }

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,17 +1,14 @@
 export default function TodoList(params) {
-  const { $target, toggleTodo } = params;
+  const { $target, toggleTodo, removeTodo } = params;
   let data = params.data || [];
 
   $target.addEventListener("click", e => {
+    const { id } = e.toElement.parentElement.parentElement.dataset;
     if (e.target.className === "toggle") {
-      const { id } = e.toElement.parentElement.parentElement.dataset;
       toggleTodo(id);
     }
-
     if (e.target.className === "destroy") {
-      const { id } = e.toElement.parentElement.parentElement.dataset;
-      data.splice(id, 1);
-      this.render();
+      removeTodo(id);
     }
   });
 

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,4 +1,5 @@
-import { classNames, keyCodes } from "./utils/constants"
+import { classNames, keyCodes } from "./utils/constants.js";
+import { todoListTemplate } from "./utils/templates.js";
 
 export default function TodoList(params) {
   const { $target, toggleTodo, removeTodo, filterTodos } = params;
@@ -51,23 +52,7 @@ export default function TodoList(params) {
   };
 
   this.render = () => {
-    $target.innerHTML = filteredData
-      .map((todo, index) => {
-        const contentHtmlString = `<div class="view"> 
-        <input class="toggle" type="checkbox" ${
-          todo.isCompleted ? "checked" : ""
-        }>
-        <label class="label">${todo.content}</label>
-        <button class="destroy"></button></div>
-        <input class="edit" value="${todo.content}">`;
-        const completedClassName = todo.isCompleted
-          ? `class = "completed"`
-          : "";
-        const editingClassName = todo.onEdit ? `class = "editing"` : "";
-
-        return `<li ${completedClassName} ${editingClassName} data-id="${index}">${contentHtmlString}</li>`;
-      })
-      .join("");
+    $target.innerHTML = filteredData.map(todoListTemplate).join("");
   };
 
   this.render();

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -32,7 +32,7 @@ export default function TodoList(params) {
   $target.addEventListener("keydown", e => {
     if (e.target.className === classNameMap.EDIT) {
       const { id } = e.target.parentElement.dataset;
-      if (e.keyCode === keyCodeMap.ENTER) {
+      if (e.keyCode === keyCodeMap.ENTER && e.target.value) {
         data[id].content = e.target.value;
         data[id].onEdit = false;
         this.render();

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -13,10 +13,10 @@ export default function TodoList(params) {
 
   $target.addEventListener("click", e => {
     const { id } = e.target.closest("li").dataset;
-    if (e.target.className === classNameMap.TOGGLE) {
+    if (e.target.classList.contains(classNameMap.TOGGLE)) {
       toggleTodo(id);
     }
-    else if (e.target.className === classNameMap.REMOVE) {
+    else if (e.target.classList.contains(classNameMap.REMOVE)) {
       removeTodo(id);
     }
   });

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -4,8 +4,14 @@ export default function TodoList(params) {
 
   $target.addEventListener("click", e => {
     if (e.target.className === "toggle") {
-      const { id } = e.toElement.parentElement.parentElement.dataset
-      data[id].isCompleted = e.toElement.checked
+      const { id } = e.toElement.parentElement.parentElement.dataset;
+      data[id].isCompleted = e.toElement.checked;
+      this.render();
+    }
+
+    if (e.target.className === "destroy") {
+      const { id } = e.toElement.parentElement.parentElement.dataset;
+      data.splice(id, 1);
       this.render();
     }
   });
@@ -19,14 +25,13 @@ export default function TodoList(params) {
     $target.innerHTML = data
       .map((todo, index) => {
         return todo.isCompleted
-        ? `<li class="completed" data-id="${index}">
+          ? `<li class="completed" data-id="${index}">
         <div class="view">
          <input class="toggle" type="checkbox" checked="true">
          <label class="label">${todo.content}</label>
          <button class="destroy"></button>
        </div></li>`
-        :
-        `<li data-id="${index}">
+          : `<li data-id="${index}">
         <div class="view">
          <input class="toggle" type="checkbox">
          <label class="label">${todo.content}</label>

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,4 +1,4 @@
-import { classNames } from "./utils/constants"
+import { classNames, keyCodes } from "./utils/constants"
 
 export default function TodoList(params) {
   const { $target, toggleTodo, removeTodo, filterTodos } = params;
@@ -26,15 +26,13 @@ export default function TodoList(params) {
 
   $target.addEventListener("keydown", e => {
     if (e.target.className === classNames.EDIT) {
-      const ENTER_KEY_CODE = 13;
-      const ESC_KEY_CODE = 27;
-      if (e.keyCode === ENTER_KEY_CODE) {
+      if (e.keyCode === keyCodes.ENTER) {
         const { id } = e.target.parentElement.dataset;
         data[id].content = e.target.value;
         data[id].onEdit = false;
         this.render();
       }
-      if (e.keyCode === ESC_KEY_CODE) {
+      if (e.keyCode === keyCodes.ESC) {
         const { id } = e.target.parentElement.dataset;
         data[id].onEdit = false;
         this.render();

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,13 +1,11 @@
 export default function TodoList(params) {
-  const { $target } = params;
+  const { $target, toggleTodo } = params;
   let data = params.data || [];
 
   $target.addEventListener("click", e => {
     if (e.target.className === "toggle") {
       const { id } = e.toElement.parentElement.parentElement.dataset;
-      console.log(e.toElement.checked);
-      data[id].isCompleted = e.toElement.checked;
-      this.render();
+      toggleTodo(id);
     }
 
     if (e.target.className === "destroy") {

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,5 +1,5 @@
 export default function TodoList(params) {
-  const $target = params.$target;
+  const { $target } = params;
   let data = params.data || [];
 
   this.setState = nextData => {

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -46,7 +46,6 @@ export default function TodoList(params) {
   this.setState = (nextData, nextFilter) => {
     data = nextData || data;
     filter = nextFilter || filter;
-    console.log(filter);
     filteredData = filterTodos(data, filter);
     this.render();
   };

--- a/mission001/hsna7024/js/TodoList.js
+++ b/mission001/hsna7024/js/TodoList.js
@@ -1,3 +1,5 @@
+import { classNames } from "./utils/constants"
+
 export default function TodoList(params) {
   const { $target, toggleTodo, removeTodo, filterTodos } = params;
   let data = params.data || [];
@@ -6,16 +8,16 @@ export default function TodoList(params) {
 
   $target.addEventListener("click", e => {
     const { id } = e.toElement.parentElement.parentElement.dataset;
-    if (e.target.className === "toggle") {
+    if (e.target.className === classNames.TOGGLE) {
       toggleTodo(id);
     }
-    if (e.target.className === "destroy") {
+    if (e.target.className === classNames.REMOVE) {
       removeTodo(id);
     }
   });
 
   $target.addEventListener("dblclick", e => {
-    if (e.target.className === "label") {
+    if (e.target.className === classNames.LABEL) {
       const { id } = e.toElement.parentElement.parentElement.dataset;
       data[id].onEdit = true;
       this.render();
@@ -23,7 +25,7 @@ export default function TodoList(params) {
   });
 
   $target.addEventListener("keydown", e => {
-    if (e.target.className === "edit") {
+    if (e.target.className === classNames.EDIT) {
       const ENTER_KEY_CODE = 13;
       const ESC_KEY_CODE = 27;
       if (e.keyCode === ENTER_KEY_CODE) {
@@ -40,13 +42,13 @@ export default function TodoList(params) {
     }
   });
 
-  filteredData = filterTodos(data, filter)
+  filteredData = filterTodos(data, filter);
 
   this.setState = (nextData, nextFilter) => {
     data = nextData || data;
     filter = nextFilter || filter;
-    console.log(filter)
-    filteredData = filterTodos(data, filter)
+    console.log(filter);
+    filteredData = filterTodos(data, filter);
     this.render();
   };
 

--- a/mission001/hsna7024/js/main.js
+++ b/mission001/hsna7024/js/main.js
@@ -2,13 +2,16 @@ import App from "./App.js";
 
 const data = [
   {
-    content: "새로운 타이틀"
+    content: "새로운 타이틀",
+    isCompleted: false
   },
   {
-    content: "완료된 타이틀"
+    content: "완료된 타이틀",
+    isCompleted: true
   },
   {
-    content: "완료된 타이틀"
+    content: "완료된 타이틀",
+    isCompleted: true
   }
 ];
 

--- a/mission001/hsna7024/js/main.js
+++ b/mission001/hsna7024/js/main.js
@@ -22,6 +22,7 @@ const init = () => {
   const app = new App({
     $targetTodoList: document.querySelector("#todo-list"),
     $targetTodoInput: document.querySelector("#new-todo-title"),
+    $targetTodoCount: document.querySelector(".todo-count"),
     data
   });
 };

--- a/mission001/hsna7024/js/main.js
+++ b/mission001/hsna7024/js/main.js
@@ -1,0 +1,22 @@
+import App from "./App.js";
+
+const data = [
+  {
+    content: "새로운 타이틀"
+  },
+  {
+    content: "완료된 타이틀"
+  },
+  {
+    content: "완료된 타이틀"
+  }
+];
+
+const init = () => {
+  const app = new App({
+    $targetTodoList: document.querySelector("#todo-list"),
+    data
+  });
+};
+
+init();

--- a/mission001/hsna7024/js/main.js
+++ b/mission001/hsna7024/js/main.js
@@ -15,6 +15,7 @@ const data = [
 const init = () => {
   const app = new App({
     $targetTodoList: document.querySelector("#todo-list"),
+    $targetTodoInput: document.querySelector("#new-todo-title"),
     data
   });
 };

--- a/mission001/hsna7024/js/main.js
+++ b/mission001/hsna7024/js/main.js
@@ -23,6 +23,8 @@ const init = () => {
     $targetTodoList: document.querySelector("#todo-list"),
     $targetTodoInput: document.querySelector("#new-todo-title"),
     $targetTodoCount: document.querySelector(".todo-count"),
+    $targetTodoFilter: document.querySelector(".filters"),
+    filter: "all selected",
     data
   });
 };

--- a/mission001/hsna7024/js/main.js
+++ b/mission001/hsna7024/js/main.js
@@ -1,5 +1,5 @@
 import App from "./App.js";
-import { filters } from "./utils/constants.js";
+import { filterMap } from "./utils/constants.js";
 
 const data = [
   {
@@ -25,7 +25,7 @@ const init = () => {
     $targetTodoInput: document.querySelector("#new-todo-title"),
     $targetTodoCount: document.querySelector(".todo-count"),
     $targetTodoFilter: document.querySelector(".filters"),
-    filter: filters.ALL,
+    filter: filterMap.ALL,
     data
   });
 };

--- a/mission001/hsna7024/js/main.js
+++ b/mission001/hsna7024/js/main.js
@@ -3,15 +3,18 @@ import App from "./App.js";
 const data = [
   {
     content: "새로운 타이틀",
-    isCompleted: false
+    isCompleted: false,
+    onEdit: false
   },
   {
     content: "완료된 타이틀",
-    isCompleted: true
+    isCompleted: true,
+    onEdit: false
   },
   {
     content: "완료된 타이틀",
-    isCompleted: true
+    isCompleted: true,
+    onEdit: false
   }
 ];
 

--- a/mission001/hsna7024/js/main.js
+++ b/mission001/hsna7024/js/main.js
@@ -1,4 +1,5 @@
 import App from "./App.js";
+import { filters } from "./utils/constants.js";
 
 const data = [
   {
@@ -24,7 +25,7 @@ const init = () => {
     $targetTodoInput: document.querySelector("#new-todo-title"),
     $targetTodoCount: document.querySelector(".todo-count"),
     $targetTodoFilter: document.querySelector(".filters"),
-    filter: "all selected",
+    filter: filters.ALL,
     data
   });
 };

--- a/mission001/hsna7024/js/utils/constants.js
+++ b/mission001/hsna7024/js/utils/constants.js
@@ -15,3 +15,7 @@ export const keyCodeMap = {
   ENTER: 13,
   ESC: 27
 }
+
+export const errorMessageMap = {
+  IS_NO_TARGET: 'target element가 없습니다.',
+}

--- a/mission001/hsna7024/js/utils/constants.js
+++ b/mission001/hsna7024/js/utils/constants.js
@@ -1,5 +1,12 @@
 export const filters = {
-  ALL : "all selected",
-  ACTIVE : "active",
-  COMPLETED : "completed"
-}
+  ALL: "all selected",
+  ACTIVE: "active",
+  COMPLETED: "completed"
+};
+
+export const classNames = {
+  TOGGLE: "toggle",
+  REMOVE: "destroy",
+  LABEL: "label",
+  EDIT: "edit"
+};

--- a/mission001/hsna7024/js/utils/constants.js
+++ b/mission001/hsna7024/js/utils/constants.js
@@ -1,21 +1,21 @@
 export const filterMap = {
   ALL: "all",
   ACTIVE: "active",
-  COMPLETED: "completed"
+  COMPLETED: "completed",
 };
 
 export const classNameMap = {
   TOGGLE: "toggle",
   REMOVE: "destroy",
   LABEL: "label",
-  EDIT: "edit"
+  EDIT: "edit",
 };
 
 export const keyMap = {
   ENTER: "Enter",
-  ESC: "Escape"
-}
+  ESC: "Escape",
+};
 
 export const errorMessageMap = {
-  IS_NO_TARGET: 'target element가 없습니다.',
-}
+  IS_NO_TARGET: "target element가 없습니다.",
+};

--- a/mission001/hsna7024/js/utils/constants.js
+++ b/mission001/hsna7024/js/utils/constants.js
@@ -11,9 +11,9 @@ export const classNameMap = {
   EDIT: "edit"
 };
 
-export const keyCodeMap = {
-  ENTER: 13,
-  ESC: 27
+export const keyMap = {
+  ENTER: "Enter",
+  ESC: "Escape"
 }
 
 export const errorMessageMap = {

--- a/mission001/hsna7024/js/utils/constants.js
+++ b/mission001/hsna7024/js/utils/constants.js
@@ -1,17 +1,17 @@
-export const filters = {
+export const filterMap = {
   ALL: "all",
   ACTIVE: "active",
   COMPLETED: "completed"
 };
 
-export const classNames = {
+export const classNameMap = {
   TOGGLE: "toggle",
   REMOVE: "destroy",
   LABEL: "label",
   EDIT: "edit"
 };
 
-export const keyCodes = {
+export const keyCodeMap = {
   ENTER: 13,
   ESC: 27
 }

--- a/mission001/hsna7024/js/utils/constants.js
+++ b/mission001/hsna7024/js/utils/constants.js
@@ -1,5 +1,5 @@
 export const filters = {
-  ALL: "all selected",
+  ALL: "all",
   ACTIVE: "active",
   COMPLETED: "completed"
 };

--- a/mission001/hsna7024/js/utils/constants.js
+++ b/mission001/hsna7024/js/utils/constants.js
@@ -10,3 +10,8 @@ export const classNames = {
   LABEL: "label",
   EDIT: "edit"
 };
+
+export const keyCodes = {
+  ENTER: 13,
+  ESC: 27
+}

--- a/mission001/hsna7024/js/utils/constants.js
+++ b/mission001/hsna7024/js/utils/constants.js
@@ -1,0 +1,5 @@
+export const filters = {
+  ALL : "all selected",
+  ACTIVE : "active",
+  COMPLETED : "completed"
+}

--- a/mission001/hsna7024/js/utils/templates.js
+++ b/mission001/hsna7024/js/utils/templates.js
@@ -21,3 +21,7 @@ export const todoFilterTemplate = () => {
     <a class="completed" href="#/completed">완료한 일</a>
   </li>`;
 };
+
+export const todoCountTemplate = length => {
+  return `총 <strong>${length}</strong> 개`;
+};

--- a/mission001/hsna7024/js/utils/templates.js
+++ b/mission001/hsna7024/js/utils/templates.js
@@ -1,11 +1,13 @@
 import { filterMap } from "./constants.js";
 
 export const todoListTemplate = (todo, index) => {
-  const contentHtmlString = `<div class="view"> 
-  <input class="toggle" type="checkbox" ${todo.isCompleted ? "checked" : ""}>
-  <label class="label">${todo.content}</label>
-  <button class="destroy"></button></div>
-  <input class="edit" value="${todo.content}">`;
+  const contentHtmlString = `
+    <div class="view"> 
+      <input class="toggle" type="checkbox" ${todo.isCompleted ? "checked" : ""}>
+      <label class="label">${todo.content}</label>
+      <button class="destroy"></button>
+    </div>
+    <input class="edit" value="${todo.content}">`;
   const completedClassName = todo.isCompleted ? `class = "completed"` : "";
   const editingClassName = todo.onEdit ? `class = "editing"` : "";
 
@@ -17,15 +19,16 @@ export const todoFilterTemplate = filter => {
   const activeSelected = filter === filterMap.ACTIVE ? " selected" : "";
   const completedSelected = filter === filterMap.COMPLETED ? " selected" : "";
 
-  return `<li>
-    <a class="all${allSelected}" href="#/">전체보기</a>
-  </li>
-  <li>
-    <a class="active${activeSelected}" href="#/active">해야할 일</a>
-  </li>
-  <li>
-    <a class="completed${completedSelected}" href="#/completed">완료한 일</a>
-  </li>`;
+  return `
+    <li>
+      <a class="all${allSelected}" href="#/">전체보기</a>
+    </li>
+    <li>
+      <a class="active${activeSelected}" href="#/active">해야할 일</a>
+    </li>
+    <li>
+      <a class="completed${completedSelected}" href="#/completed">완료한 일</a>
+    </li>`;
 };
 
 export const todoCountTemplate = length => {

--- a/mission001/hsna7024/js/utils/templates.js
+++ b/mission001/hsna7024/js/utils/templates.js
@@ -1,3 +1,5 @@
+import { filters } from "./constants.js";
+
 export const todoListTemplate = (todo, index) => {
   const contentHtmlString = `<div class="view"> 
   <input class="toggle" type="checkbox" ${todo.isCompleted ? "checked" : ""}>
@@ -10,15 +12,19 @@ export const todoListTemplate = (todo, index) => {
   return `<li ${completedClassName} ${editingClassName} data-id="${index}">${contentHtmlString}</li>`;
 };
 
-export const todoFilterTemplate = () => {
+export const todoFilterTemplate = filter => {
+  const allSelected = filter === filters.ALL ? " selected" : "";
+  const activeSelected = filter === filters.ACTIVE ? " selected" : "";
+  const completedSelected = filter === filters.COMPLETED ? " selected" : "";
+
   return `<li>
-    <a class="all selected" href="#/">전체보기</a>
+    <a class="all${allSelected}" href="#/">전체보기</a>
   </li>
   <li>
-    <a class="active" href="#/active">해야할 일</a>
+    <a class="active${activeSelected}" href="#/active">해야할 일</a>
   </li>
   <li>
-    <a class="completed" href="#/completed">완료한 일</a>
+    <a class="completed${completedSelected}" href="#/completed">완료한 일</a>
   </li>`;
 };
 

--- a/mission001/hsna7024/js/utils/templates.js
+++ b/mission001/hsna7024/js/utils/templates.js
@@ -1,0 +1,23 @@
+export const todoListTemplate = (todo, index) => {
+  const contentHtmlString = `<div class="view"> 
+  <input class="toggle" type="checkbox" ${todo.isCompleted ? "checked" : ""}>
+  <label class="label">${todo.content}</label>
+  <button class="destroy"></button></div>
+  <input class="edit" value="${todo.content}">`;
+  const completedClassName = todo.isCompleted ? `class = "completed"` : "";
+  const editingClassName = todo.onEdit ? `class = "editing"` : "";
+
+  return `<li ${completedClassName} ${editingClassName} data-id="${index}">${contentHtmlString}</li>`;
+};
+
+export const todoFilterTemplate = () => {
+  `<li>
+    <a class="all selected" href="#/">전체보기</a>
+  </li>
+  <li>
+    <a class="active" href="#/active">해야할 일</a>
+  </li>
+  <li>
+    <a class="completed" href="#/completed">완료한 일</a>
+  </li>`;
+};

--- a/mission001/hsna7024/js/utils/templates.js
+++ b/mission001/hsna7024/js/utils/templates.js
@@ -1,4 +1,4 @@
-import { filters } from "./constants.js";
+import { filterMap } from "./constants.js";
 
 export const todoListTemplate = (todo, index) => {
   const contentHtmlString = `<div class="view"> 
@@ -13,9 +13,9 @@ export const todoListTemplate = (todo, index) => {
 };
 
 export const todoFilterTemplate = filter => {
-  const allSelected = filter === filters.ALL ? " selected" : "";
-  const activeSelected = filter === filters.ACTIVE ? " selected" : "";
-  const completedSelected = filter === filters.COMPLETED ? " selected" : "";
+  const allSelected = filter === filterMap.ALL ? " selected" : "";
+  const activeSelected = filter === filterMap.ACTIVE ? " selected" : "";
+  const completedSelected = filter === filterMap.COMPLETED ? " selected" : "";
 
   return `<li>
     <a class="all${allSelected}" href="#/">전체보기</a>

--- a/mission001/hsna7024/js/utils/templates.js
+++ b/mission001/hsna7024/js/utils/templates.js
@@ -11,7 +11,7 @@ export const todoListTemplate = (todo, index) => {
 };
 
 export const todoFilterTemplate = () => {
-  `<li>
+  return `<li>
     <a class="all selected" href="#/">전체보기</a>
   </li>
   <li>

--- a/mission001/hsna7024/js/utils/templates.js
+++ b/mission001/hsna7024/js/utils/templates.js
@@ -3,13 +3,15 @@ import { filterMap } from "./constants.js";
 export const todoListTemplate = (todo, index) => {
   const contentHtmlString = `
     <div class="view"> 
-      <input class="toggle" type="checkbox" ${todo.isCompleted ? "checked" : ""}>
+      <input class="toggle" type="checkbox" ${
+        todo.isCompleted ? "checked" : ""
+      }>
       <label class="label">${todo.content}</label>
       <button class="destroy"></button>
     </div>
     <input class="edit" value="${todo.content}">`;
-  const completedClassName = todo.isCompleted ? `class = "completed"` : "";
-  const editingClassName = todo.onEdit ? `class = "editing"` : "";
+  const completedClassName = todo.isCompleted ? 'class = "completed"' : "";
+  const editingClassName = todo.onEdit ? 'class = "editing"' : "";
 
   return `<li ${completedClassName} ${editingClassName} data-id="${index}">${contentHtmlString}</li>`;
 };
@@ -31,6 +33,4 @@ export const todoFilterTemplate = filter => {
     </li>`;
 };
 
-export const todoCountTemplate = length => {
-  return `총 <strong>${length}</strong> 개`;
-};
+export const todoCountTemplate = length => `총 <strong>${length}</strong> 개`;

--- a/mission001/hsna7024/package.json
+++ b/mission001/hsna7024/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "hsna7024",
+  "version": "1.0.0",
+  "description": "mission1",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-plugin-import": "^2.20.1"
+  }
+}


### PR DESCRIPTION
## 미션내용
#1 

## 진행상황

- [x] todo list에 todoItem을 키보드로 입력하여 추가
- [x]  todo list의 체크박스를 클릭하여 complete 상태로 변경. (li tag 에 completed class 추가)
- [x] todo list의 x버튼을 이용해서 해당 엘리먼트를 삭제
- [x] todo list를 더블클릭했을 때 input 모드로 변경. (li tag 에 editing class 추가) 단 이때 수정을 완료하지 않은 상태에서 esc키를 누르면 수정되지 않은 채로 다시 view 모드로 복귀
- [x] todo list의 item갯수를 count한 갯수를 리스트의 하단에 보여주기
- [x] todo list의 상태값을 확인하여, 해야할 일과, 완료한 일을 클릭하면 해당 상태의 아이템만 보여주기

## 소감

스터디에 진행했던 내용이라 금방 마무리 할 줄 알았는데 오래 걸렸네요 ㅠㅠ
따로 리뷰어가 지정 안되어 있어서 우선 PR 올리겠습니다.

가장 어려웠던 점은 list의 상태값에 때라 분류하는 기능이였습니다.
분류하는거 자체는 구현할 수 있었지만 분류 후에도 같은 데이터를 유지하도록 구현하는게 어려웠습니다.
App 컴포넌트에서 전체의 data를 관리하고 todoList render할 때는 data 중에 active와 completed에 맞게 filter 후에 render 해줬습니다.
문제는 인덱스를 li 순서대로 정해 놓았기 때문에 todo를 갱신할 때 정상 동작을 못하고 있네요. 고유 id로 구분하면 해결 될 것 같은데 해결법이 딱히 떠오르지 않아 현재 상태로 우선 제출합니다.

그리고 validation 부분도 잘 안됐습니다. target 엘리먼트가 있는지와 타이핑시 공백으로 입력을 주는지 2가지만 확인하고 있습니다.

전체적으로 로토가 알려주셨던 구조를 유지하려고 했습니다.
각 컴포넌트는 각자의 할 일을 수행하고 App에서 data와 component를 사용하도록.
하지만 미션을 수행 할 수록 난잡해진 부분이 있네요.
더 열심히 해야겠습니다.

 
